### PR TITLE
Restore DUoM values when reopening Item Tracking Lines

### DIFF
--- a/app/src/codeunit/DUoMTrackingCopySubscribers.Codeunit.al
+++ b/app/src/codeunit/DUoMTrackingCopySubscribers.Codeunit.al
@@ -97,6 +97,21 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
         TrackingSpecification."DUoM Second Qty" := ReservEntry."DUoM Second Qty";
     end;
 
+
+    // ── Reservation Entry → Tracking Specification (ruta alternativa de inicialización) ──
+    // Algunas rutas de reapertura de Item Tracking Lines inicializan Tracking Specification
+    // desde Reservation Entry usando InitFromReservEntry en lugar de CopyTrackingFromReservEntry.
+    // Este subscriber espejo asegura que los campos DUoM también se restauran en ese flujo.
+    [EventSubscriber(ObjectType::Table, Database::"Tracking Specification",
+        'OnAfterInitFromReservEntry', '', false, false)]
+    local procedure TrackingSpecOnAfterInitFromReservEntry(
+        var TrackingSpecification: Record "Tracking Specification";
+        ReservEntry: Record "Reservation Entry")
+    begin
+        TrackingSpecification."DUoM Ratio" := ReservEntry."DUoM Ratio";
+        TrackingSpecification."DUoM Second Qty" := ReservEntry."DUoM Second Qty";
+    end;
+
     // ── Tracking Specification → Item Journal Line ────────────────────────────
     // Publisher: Table "Item Journal Line" (83), evento OnAfterCopyTrackingFromSpec.
     // Patrón: Codeunit 6516 "Package Management" línea 774. Firma BC 27 confirmada.


### PR DESCRIPTION
### Motivation
- Reopening the Item Tracking Lines page could show `DUoM Ratio` and `DUoM Second Qty` as zero because some reopen flows initialize the `Tracking Specification` buffer via `InitFromReservEntry` instead of the `CopyTrackingFromReservEntry` path that already restored DUoM values.

### Description
- Added an `EventSubscriber` for `Tracking Specification` on `OnAfterInitFromReservEntry` in codeunit `50110` that copies `DUoM Ratio` and `DUoM Second Qty` from `Reservation Entry` into the tracking buffer. 
- The new subscriber mirrors the existing `OnAfterCopyTrackingFromReservEntry` logic so DUoM fields are restored on the alternate initialization path and no posting logic is modified.

### Testing
- No automated AL/unit tests were executed for this change.
- Repo-level verification commands (`git diff`, `git status`) and the commit operation were run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50d9e7064832aada16abff0afe00c)