### PR TITLE
Use Close() and update comment in DUoM Purch Track Close Tests

### DIFF
--- a/test/src/codeunit/DUoMPurchTrackingCloseTests.Codeunit.al
+++ b/test/src/codeunit/DUoMPurchTrackingCloseTests.Codeunit.al
@@ -405,7 +405,7 @@ codeunit 50222 "DUoM Purch Track Close Tests"
     ///                    Suma = 3 ≠ 4 → al invocar OK provoca error de validación DUoM
     ///
     ///   HandlerStep = 5: Lote HH (ratio=2) + Lote LOL (ratio=3) → suma incoherente
-    ///                    pero se invoca Cancel → sin error, sin persistencia
+    ///                    pero se cierra la página sin OK → sin error, sin persistencia
     ///
     /// Notas:
     ///   - En modo Variable sin DUoM Lot Ratio registrado, el subscriber aplica el
@@ -489,7 +489,7 @@ codeunit 50222 "DUoM Purch Track Close Tests"
                     ItemTrackingLines."Quantity (Base)".SetValue(1);
                     ItemTrackingLines."DUoM Ratio".SetValue(3);
                     // DUoM Second Qty = 3; suma total = 5 ≠ 4 pero...
-                    ItemTrackingLines.Cancel().Invoke();   // Cancel: no ejecuta validación DUoM
+                    ItemTrackingLines.Close();              // Cierre sin OK: no ejecuta validación DUoM
                 end;
         end;
     end;


### PR DESCRIPTION
### Motivation
- Align the test modal handler with the intended behavior for handler step 5 by closing the page without invoking OK so DUoM validation is not executed.

### Description
- Replaced `ItemTrackingLines.Cancel().Invoke();` with `ItemTrackingLines.Close();` in `ItemTrackingLines_CloseTest_MPH` for HandlerStep 5.
- Updated the adjacent comment from "se invoca Cancel" to "se cierra la página sin OK" to accurately describe the action.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6fe29e4e8832a9416fb50d2e951d2)