### PR TITLE
Regla de legibilidad: evitar `if` anidados, workflow CI y actualización de tests de undo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,6 +73,9 @@ Los identificadores AL (nombres de objetos, campos, procedimientos, variables) y
 - **Object name length limit:** All AL object names (tables, pages, codeunits, page extensions,
   etc.) **must not exceed 30 characters** (compiler limit AL0305). Verify length before opening
   a PR. Page extension names must be especially compact to leave room for the `DUoM` prefix.
+- **Readability rule (mandatory):** avoid nested/chained `if` structures. Use at most one
+  nesting level per logic block and prefer guard clauses, `case`, or helper extraction.
+  This rule applies to both existing and new code.
 
 ## AL object ID rules (mandatory)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,6 +29,7 @@
 ## Checklist general AL
 
 - [ ] Los identificadores AL no superan 30 caracteres (límite AL0305).
+- [ ] No hay `if` anidados/encadenados evitables; he aplicado guard clauses, `case` o helpers cuando corresponde.
 - [ ] Todos los textos visibles al usuario son `Label` con `Comment` de descripción de placeholders.
 - [ ] Los archivos XLF (`en-US` y `es-ES`) están actualizados si se añadieron o cambiaron cadenas.
 - [ ] Los nuevos objetos `table` tienen entrada en `DUoM - All` y en `DUoM - Test All`.

--- a/.github/workflows/NoNestedIfCheck.yaml
+++ b/.github/workflows/NoNestedIfCheck.yaml
@@ -1,0 +1,27 @@
+name: 'No Nested If Check'
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  nested-if-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Detect nested/chain if patterns in AL
+        run: |
+          set -euo pipefail
+          # Aplica sobre TODO el código existente y nuevo del repositorio.
+          # Si hay deuda técnica previa, este check fallará hasta que quede depurada.
+          if rg -nUP "if\s+.+\s+then\s+begin[\s\S]{0,400}?\bif\s+.+\s+then" app/src test/src; then
+            echo "Se detectaron posibles if anidados/encadenados."
+            exit 1
+          fi
+
+          echo "No se detectaron patrones de if anidados/encadenados según la regla del proyecto."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,30 @@ Un PR sin esta declaración explícita no cumple la definición de trabajo compl
 - Librería de aserciones: `Library Assert` (Microsoft).
 - Ningún test puede desactivarse para que pase el CI.
 
+---
+
+## Regla de legibilidad: evitar `if` anidados/encadenados
+
+> **No se permiten estructuras `if` anidadas o encadenadas cuando exista una alternativa clara de diseño.**
+
+### Norma del proyecto
+
+- Máximo **1 nivel** de anidación de `if` por bloque de lógica.
+- No encadenar múltiples `if/else if` para reglas complejas: preferir `case` o extracción a helpers con nombre semántico.
+- Priorizar **guard clauses** (`exit`, `Error`) para cortar flujo temprano.
+
+### Refactor recomendado
+
+1. Invertir condición y salir pronto.
+2. Extraer validaciones a funciones pequeñas (`Is...`, `Can...`, `Should...`).
+3. Reemplazar cascadas condicionales por `case` o por una función de decisión.
+
+### Cumplimiento en PR
+
+- Todo PR debe declarar explícitamente que revisó esta regla en el checklist.
+- Si hay una excepción, documentarla y justificar por qué no se pudo simplificar.
+- La regla aplica al **código existente y nuevo**: no se admite deuda técnica activa de `if` anidados/encadenados.
+
 ### Norma de creación de datos de test (obligatoria)
 
 En el código de tests, **si existe un helper estándar de Microsoft `Library - *` que cubra

--- a/test/src/codeunit/DUoMUndoRcptShptTests.Codeunit.al
+++ b/test/src/codeunit/DUoMUndoRcptShptTests.Codeunit.al
@@ -36,7 +36,7 @@
 /// Convenciones de test:
 ///   - Patrón [GIVEN] / [WHEN] / [THEN].
 ///   - LibraryPurchase, LibrarySales, LibraryInventory, LibraryAssert según norma.
-///   - Anulación via CODEUNIT.Run("Undo Purchase Receipt" / "Undo Sales Shipment").
+///   - Anulación via CODEUNIT.Run("Undo Purchase Receipt Line" / "Undo Sales Shipment Line").
 /// </summary>
 codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
 {
@@ -86,7 +86,7 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         LibraryAssert.IsTrue(PurchRcptHeader.FindFirst(), 'T-UNDO-01: Se esperaba albarán contabilizado');
         PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
         LibraryAssert.IsTrue(PurchRcptLine.FindFirst(), 'T-UNDO-01: Se esperaba línea de albarán');
-        CODEUNIT.Run(CODEUNIT::"Undo Purchase Receipt", PurchRcptLine);
+        CODEUNIT.Run(CODEUNIT::"Undo Purchase Receipt Line", PurchRcptLine);
 
         // [THEN] ILE original: Qty = +10, DUoM Ratio = 0.8, DUoM Second Qty = +8
         ILE.SetRange("Item No.", Item."No.");
@@ -154,7 +154,7 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         LibraryAssert.IsTrue(PurchRcptHeader.FindFirst(), 'T-UNDO-02: Se esperaba albarán contabilizado');
         PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
         LibraryAssert.IsTrue(PurchRcptLine.FindFirst(), 'T-UNDO-02: Se esperaba línea de albarán');
-        CODEUNIT.Run(CODEUNIT::"Undo Purchase Receipt", PurchRcptLine);
+        CODEUNIT.Run(CODEUNIT::"Undo Purchase Receipt Line", PurchRcptLine);
 
         // [THEN] ILE original: Qty = +10, DUoM Ratio = 0.8, DUoM Second Qty = +8
         ILE.SetRange("Item No.", Item."No.");
@@ -226,7 +226,7 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         LibraryAssert.IsTrue(PurchRcptHeader.FindFirst(), 'T-UNDO-03: Se esperaba albarán contabilizado');
         PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
         LibraryAssert.IsTrue(PurchRcptLine.FindFirst(), 'T-UNDO-03: Se esperaba línea de albarán');
-        CODEUNIT.Run(CODEUNIT::"Undo Purchase Receipt", PurchRcptLine);
+        CODEUNIT.Run(CODEUNIT::"Undo Purchase Receipt Line", PurchRcptLine);
 
         // [THEN] Suma de DUoM Second Qty de ILEs originales = +14.4
         ILE.SetRange("Item No.", Item."No.");
@@ -309,7 +309,7 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         SalesShipmentLine.SetRange("Document No.", SalesShipmentHeader."No.");
         SalesShipmentLine.SetRange(Type, SalesShipmentLine.Type::Item);
         LibraryAssert.IsTrue(SalesShipmentLine.FindFirst(), 'T-UNDO-04: Se esperaba línea albarán venta');
-        CODEUNIT.Run(CODEUNIT::"Undo Sales Shipment", SalesShipmentLine);
+        CODEUNIT.Run(CODEUNIT::"Undo Sales Shipment Line", SalesShipmentLine);
 
         // [THEN] ILE original (venta): Qty = -10, DUoM Second Qty = -8
         ILE.SetRange("Item No.", Item."No.");
@@ -389,7 +389,7 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         SalesShipmentLine.SetRange("Document No.", SalesShipmentHeader."No.");
         SalesShipmentLine.SetRange(Type, SalesShipmentLine.Type::Item);
         LibraryAssert.IsTrue(SalesShipmentLine.FindFirst(), 'T-UNDO-05: Se esperaba línea albarán venta');
-        CODEUNIT.Run(CODEUNIT::"Undo Sales Shipment", SalesShipmentLine);
+        CODEUNIT.Run(CODEUNIT::"Undo Sales Shipment Line", SalesShipmentLine);
 
         // [THEN] ILE original (venta): Qty = -5, DUoM Ratio = 1.25, Second Qty = -6.25
         ILE.SetRange("Item No.", Item."No.");


### PR DESCRIPTION
### Motivation
- Introducir una norma de legibilidad para evitar estructuras `if` anidadas/encadenadas y promover guard clauses, `case` o extracción de helpers para mejorar mantenibilidad.
- Añadir un chequeo automático en CI para detectar deuda técnica existente y evitar nuevas violaciones de la regla.
- Actualizar los tests que invocaban los antiguos codeunits de undo para usar las nuevas entradas `Undo Purchase Receipt Line` / `Undo Sales Shipment Line` y mantener coherencia con la lógica de undo.

### Description
- Se añadió la regla de legibilidad al archivo de instrucciones del agente en `/.github/copilot-instructions.md` indicando máximo un nivel de anidación de `if` y preferencia por guard clauses, `case` o helpers. 
- Se añadió una entrada de checklist en `/.github/pull_request_template.md` para que los PR verifiquen la ausencia de `if` anidados/encadenados.
- Se creó el workflow `/.github/workflows/NoNestedIfCheck.yaml` que ejecuta una búsqueda (ripgrep) para detectar patrones de `if` anidados/encadenados en `app/src` y `test/src` y falla la PR si se encuentran coincidencias.
- Se actualizaron reglas y recomendaciones en `CONTRIBUTING.md` relacionadas con la nueva norma de legibilidad. 
- Se modificó el test `test/src/codeunit/DUoMUndoRcptShptTests.Codeunit.al` para invocar `CODEUNIT.Run(CODEUNIT::"Undo Purchase Receipt Line", ...)` y `CODEUNIT.Run(CODEUNIT::"Undo Sales Shipment Line", ...)` en lugar de las llamadas anteriores, y se ajustó un comentario descriptivo.

### Testing
- Se añadió el workflow `No Nested If Check` que actuará como chequeo automático en la CI y reportará fallos si detecta patrones de `if` anidados; este workflow será ejecutado por GitHub Actions en los PR hacia `main`.
- No se ejecutaron tests unitarios automáticos dentro de este cambio en el rollout; los tests modificados están listos para ejecutarse en la CI habitual del repositorio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0d549eb0832a9bea7ad97c212c97)