### PR TITLE
Replace invalid [TestInitialize] with Initialize pattern in DUoM tests

### DIFF
--- a/test/src/codeunit/DUoMUndoRcptShptTests.Codeunit.al
+++ b/test/src/codeunit/DUoMUndoRcptShptTests.Codeunit.al
@@ -43,16 +43,20 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
     Subtype = Test;
     TestPermissions = Disabled;
 
-    [TestInitialize]
-    procedure InitializeDUoMSetupSeed()
+    local procedure Initialize()
     var
         DUoMItemSetup: Record "DUoM Item Setup";
     begin
+        if IsInitialized then
+            exit;
+
         if not DUoMItemSetup.Get('DUOM-TEST-SEED') then begin
             DUoMItemSetup.Init();
             DUoMItemSetup."Item No." := 'DUOM-TEST-SEED';
             DUoMItemSetup.Insert();
         end;
+
+        IsInitialized := true;
     end;
 
     // -------------------------------------------------------------------------
@@ -81,6 +85,8 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryAssert: Codeunit "Library Assert";
     begin
+        Initialize();
+
         // [GIVEN] Artículo con DUoM Fixed, ratio = 0.8
         LibraryInventory.CreateItem(Item);
         DUoMTestHelpers.CreateItemSetup(Item."No.", true, 'PCS',
@@ -146,6 +152,8 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         LibraryAssert: Codeunit "Library Assert";
         LotNo: Code[50];
     begin
+        Initialize();
+
         // [GIVEN] Artículo con DUoM Variable, lot tracking activo
         LibraryInventory.CreateItem(Item);
         DUoMTestHelpers.CreateItemSetup(Item."No.", true, 'PCS',
@@ -216,6 +224,8 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         OriginalSum: Decimal;
         CorrectionSum: Decimal;
     begin
+        Initialize();
+
         // [GIVEN] Artículo con DUoM Variable, lot tracking activo
         LibraryInventory.CreateItem(Item);
         DUoMTestHelpers.CreateItemSetup(Item."No.", true, 'PCS',
@@ -295,6 +305,8 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         LibrarySales: Codeunit "Library - Sales";
         LibraryAssert: Codeunit "Library Assert";
     begin
+        Initialize();
+
         // [GIVEN] Artículo con DUoM Fixed, ratio = 0.8
         LibraryInventory.CreateItem(Item);
         DUoMTestHelpers.CreateItemSetup(Item."No.", true, 'PCS',
@@ -371,6 +383,8 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         LibraryAssert: Codeunit "Library Assert";
         LotNo: Code[50];
     begin
+        Initialize();
+
         // [GIVEN] Artículo con DUoM Variable, lot tracking activo
         LibraryInventory.CreateItem(Item);
         DUoMTestHelpers.CreateItemSetup(Item."No.", true, 'PCS',
@@ -423,4 +437,7 @@ codeunit 50227 "DUoM Undo Rcpt Shpt Tests"
         LibraryAssert.AreNearlyEqual(6.25, ILE."DUoM Second Qty", 0.001,
             'T-UNDO-05: ILE corrección venta DUoM Second Qty = +5 × 1.25 = +6.25 (signo contrario)');
     end;
+
+    var
+        IsInitialized: Boolean;
 }


### PR DESCRIPTION
### Motivation
- Fix compiler error AL0112 caused by the invalid `[TestInitialize]` attribute and align the codeunit with standard Business Central test setup patterns.

### Description
- Removed the `[TestInitialize]`-decorated procedure and preserved its seed logic inside a `local procedure Initialize()` that uses a one-time guard with `IsInitialized`.
- Inserted `Initialize();` at the start of every `[Test]` procedure so shared setup runs before each test entry point.
- Added a module-level `IsInitialized: Boolean` variable to track one-time initialization.
- Kept the original DUoM seed insert logic unchanged except for the new guard and flag assignment.

### Testing
- Ran file/content checks with `rg` to confirm `TestInitialize` is no longer present and that `Initialize()` and `IsInitialized` were added, which succeeded.
- Applied the patch to `test/src/codeunit/DUoMUndoRcptShptTests.Codeunit.al` successfully, which succeeded.
- Attempted to push changes from this environment but the push failed due to no configured remote, which prevented remote upload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa24f77330832aab836d3bbf0ab828)