### PR TITLE
Fix DUoM Second Qty propagation: sign normalization and per‑lot ratio application

### DIFF
--- a/app/src/codeunit/DUoMInventorySubscribers.Codeunit.al
+++ b/app/src/codeunit/DUoMInventorySubscribers.Codeunit.al
@@ -28,32 +28,32 @@
 /// Propagation strategy for ILE:
 ///   Two parallel mechanisms cover both paths.
 ///
-///   NORMA: ILE."DUoM Second Qty" SIEMPRE viene del IJL — asignación pura, sin cálculos.
-///   La responsabilidad de que el IJL llegue con los valores correctos (signo incluido)
-///   corresponde a los subscribers upstream de cada flujo.
+///   NORMA: ILE."DUoM Second Qty" toma el módulo desde el IJL y se firma según
+///   la dirección real del ILE. La responsabilidad de que el IJL llegue con el
+///   módulo correcto corresponde a los subscribers upstream de cada flujo.
 ///
 ///   SIN Item Tracking (artículos sin lotes / sin trazabilidad activa):
 ///     OnPostItemJnlLineOnAfterCopyDocumentFields → Purchase/Sales Line → IJL  (ya existe)
 ///     OnAfterCopyItemJnlLineFromPurchRcpt / OnAfterCopyItemJnlLineFromSalesShpt → flujo undo
-///     OnAfterInitItemLedgEntry → ILE ← IJL  (asignación pura)
+///     OnAfterInitItemLedgEntry → ILE ← IJL  (módulo IJL + signo ILE)
 ///     Este subscriber siempre se dispara, con o sin tracking activo.
 ///
 ///   CON Item Tracking (por lote, BC llama CopyTrackingFromItemJnlLine solo cuando hay Lot/Serial):
 ///     ReservEntry → TrackingSpec (OnAfterCopyTrackingFromReservEntry, codeunit 50110)
 ///     OnAfterCopyTrackingFromSpec → TrackingSpec → IJL  (refinamiento por lote)
-///     OnAfterInitItemLedgEntry → ILE ← IJL  (asignación pura)
+///     OnAfterInitItemLedgEntry → ILE ← IJL  (módulo IJL + signo ILE)
 ///     OnAfterCopyTrackingFromItemJnlLine → IJL → ILE  (codeunit 50110, ILE lee del IJL)
 ///     Orden garantizado BC 27: OnAfterInitItemLedgEntry se ejecuta ANTES de
 ///     ILECopyTrackingFromItemJnlLine.
 ///
-///   IMPORTANTE: OnAfterInitItemLedgEntry es una asignación pura. Copia DUoM Ratio y
-///   DUoM Second Qty directamente del IJL al ILE sin cálculos ni lógica condicional.
-///   La responsabilidad de que el IJL llegue con valores correctos corresponde a los
-///   subscribers upstream (flujo undo, tracking copy, etc.).
+///   IMPORTANTE: OnAfterInitItemLedgEntry copia DUoM Ratio y toma DUoM Second Qty
+///   desde el IJL, normalizando únicamente el signo contra ILE.Quantity / Signed().
+///   La responsabilidad de que el IJL llegue con el módulo correcto corresponde a
+///   los subscribers upstream (flujo undo, tracking copy, etc.).
 ///
 /// Estrategia de propagación para Value Entry:
 ///   OnAfterInitValueEntry en Codeunit "Item Jnl.-Post Line" (BC 27 / runtime 15)
-///   copia DUoM Second Qty desde la Item Journal Line al nuevo Value Entry
+///   copia DUoM Second Qty desde el Item Ledger Entry ya firmado al nuevo Value Entry
 ///   antes de Insert() — no se necesita ninguna llamada a Modify().
 ///   Firma verificada: (var ValueEntry; var ItemJournalLine; var ValueEntryNo; var ItemLedgEntry).
 /// </summary>
@@ -345,16 +345,15 @@ codeunit 50104 "DUoM Inventory Subscribers"
     local procedure OnAfterInitItemLedgEntry(var NewItemLedgEntry: Record "Item Ledger Entry"; var ItemJournalLine: Record "Item Journal Line"; var ItemLedgEntryNo: Integer)
     begin
         NewItemLedgEntry."DUoM Ratio" := ItemJournalLine."DUoM Ratio";
-        NewItemLedgEntry."DUoM Second Qty" := ItemJournalLine."DUoM Second Qty";
+        NewItemLedgEntry."DUoM Second Qty" := GetSignedSecondQtyForILE(
+            NewItemLedgEntry, ItemJournalLine, ItemJournalLine."DUoM Second Qty");
     end;
 
     /// <summary>
-    /// Asignación pura de DUoM Second Qty desde el Item Journal Line al nuevo Value Entry
-    /// antes de Insert() — sin cálculos ni lógica condicional, sin llamada a Modify().
+    /// Copia DUoM Second Qty desde el Item Ledger Entry ya firmado al nuevo Value Entry
+    /// antes de Insert() — sin llamada a Modify().
     ///
-    /// Responsabilidad única: copiar DUoM Second Qty del IJL al Value Entry.
-    /// La responsabilidad de que el IJL llegue con el valor correcto (signo incluido)
-    /// corresponde a los subscribers upstream.
+    /// Responsabilidad única: alinear el Value Entry con el ILE definitivo.
     ///
     /// Publisher: Codeunit "Item Jnl.-Post Line", evento OnAfterInitValueEntry.
     /// Firma verificada en BC 27 / runtime 15 (ItemJnlPostLine.Codeunit.al):
@@ -363,6 +362,21 @@ codeunit 50104 "DUoM Inventory Subscribers"
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Item Jnl.-Post Line", 'OnAfterInitValueEntry', '', false, false)]
     local procedure OnAfterInitValueEntry(var ValueEntry: Record "Value Entry"; var ItemJournalLine: Record "Item Journal Line"; var ValueEntryNo: Integer; var ItemLedgEntry: Record "Item Ledger Entry")
     begin
-        ValueEntry."DUoM Second Qty" := ItemJournalLine."DUoM Second Qty";
+        ValueEntry."DUoM Second Qty" := ItemLedgEntry."DUoM Second Qty";
+    end;
+
+    local procedure GetSignedSecondQtyForILE(ItemLedgerEntry: Record "Item Ledger Entry"; ItemJournalLine: Record "Item Journal Line"; SecondQty: Decimal): Decimal
+    var
+        SignedSecondQty: Decimal;
+    begin
+        SignedSecondQty := Abs(SecondQty);
+        if ItemLedgerEntry.Quantity < 0 then
+            SignedSecondQty := -SignedSecondQty
+        else
+            if ItemLedgerEntry.Quantity = 0 then
+                SignedSecondQty := ItemJournalLine.Signed(SignedSecondQty);
+        if ItemLedgerEntry.Correction then
+            SignedSecondQty := -SignedSecondQty;
+        exit(SignedSecondQty);
     end;
 }

--- a/app/src/codeunit/DUoMTrackingCopySubscribers.Codeunit.al
+++ b/app/src/codeunit/DUoMTrackingCopySubscribers.Codeunit.al
@@ -136,32 +136,37 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
     // Patrón: Codeunit 6516 "Package Management" línea 774. Firma BC 27 confirmada.
     // Motivo: BC llama esto al dividir el IJL por lote. TrackingSpecification es el del
     // lote específico. DUoM Ratio del lote llega al IJL sin ningún FindFirst().
-    // Guard: sin ratio en TrackingSpec, se sale sin sobrescribir el ratio que ya propagó
-    // OnPurchPostCopyDocFieldsToItemJnlLine desde Purchase Line (flujo sin Item Tracking
-    // o lote sin ratio DUoM registrado).
+    // Guard/fallback: si TrackingSpec no trae ratio, se intenta resolver DUoM Lot Ratio
+    // (50102) por Item/Lot antes de mantener el ratio de la línea.
     [EventSubscriber(ObjectType::Table, Database::"Item Journal Line",
         'OnAfterCopyTrackingFromSpec', '', false, false)]
     local procedure IJLCopyTrackingFromSpec(
         var ItemJournalLine: Record "Item Journal Line";
         TrackingSpecification: Record "Tracking Specification")
+    var
+        DUoMLotSubscribers: Codeunit "DUoM Lot Subscribers";
     begin
-        if TrackingSpecification."DUoM Ratio" = 0 then
+        if TrackingSpecification."DUoM Ratio" <> 0 then begin
+            ItemJournalLine."DUoM Ratio" := TrackingSpecification."DUoM Ratio";
+            ItemJournalLine."DUoM Second Qty" := TrackingSpecification."DUoM Second Qty";
             exit;
-        ItemJournalLine."DUoM Ratio" := TrackingSpecification."DUoM Ratio";
-        ItemJournalLine."DUoM Second Qty" := TrackingSpecification."DUoM Second Qty";
+        end;
+
+        ItemJournalLine."Lot No." := TrackingSpecification."Lot No.";
+        if DUoMLotSubscribers.ApplyLotRatioToItemJournalLine(ItemJournalLine) then
+            exit;
     end;
 
     // ── Item Journal Line → Item Ledger Entry ─────────────────────────────────
     // Publisher: Table "Item Ledger Entry" (32), evento OnAfterCopyTrackingFromItemJnlLine.
     // Patrón: Codeunit 6516 "Package Management" línea 551. Firma BC 27 confirmada.
-    // Motivo: BC llama esto antes de Insert() del ILE. Consolida los campos DUoM del IJL
-    // en el ILE siguiendo la norma ILE←IJL.
+    // Motivo: BC llama esto antes de Insert() del ILE. Consolida los campos DUoM por
+    // lote en el ILE siguiendo la prioridad 50102 > Tracking/IJL.
     //
     // Orden de ejecución (BC 27): este evento se dispara DESPUÉS de OnAfterInitItemLedgEntry.
-    // OnAfterInitItemLedgEntry (50104, parámetro var ItemJournalLine) ya garantiza que el
-    // IJL tiene los valores definitivos: DUoM Ratio del lote (DUoM Lot Ratio si aplica) y
-    // DUoM Second Qty (módulo). El signo se aplica aquí usando ItemLedgerEntry.Quantity
-    // (ya inicializado con signo correcto por BC antes de este evento).
+    // OnAfterInitItemLedgEntry (50104, parámetro var ItemJournalLine) puede haber copiado
+    // el total del IJL. Este subscriber recalcula DUoM Second Qty con la cantidad real del
+    // ILE split por lote para evitar duplicar totales en escenarios 1:N.
     //
     // NORMA ILE←IJL: el signo de ILE."DUoM Second Qty" sigue al de ILE.Quantity.
     // IJL.Quantity es SIEMPRE positivo en BC 27 (sin signo; la dirección la da Entry Type),
@@ -172,23 +177,31 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
     local procedure ILECopyTrackingFromItemJnlLine(
         var ItemLedgerEntry: Record "Item Ledger Entry";
         ItemJnlLine: Record "Item Journal Line")
+    var
+        DUoMLotSubscribers: Codeunit "DUoM Lot Subscribers";
+        EffectiveItemJnlLine: Record "Item Journal Line";
+        EffectiveRatio: Decimal;
     begin
-        // Guard: sin ratio DUoM en el IJL, nada que propagar al ILE.
-        // Cubre AlwaysVariable + Lot No. sin ratio (T10): Ratio = 0 aunque SecondQty ≠ 0.
-        if ItemJnlLine."DUoM Ratio" = 0 then
+        EffectiveItemJnlLine := ItemJnlLine;
+        if EffectiveItemJnlLine."Lot No." = '' then
+            EffectiveItemJnlLine."Lot No." := ItemLedgerEntry."Lot No.";
+
+        DUoMLotSubscribers.TryApplyLotRatioToILE(ItemLedgerEntry, EffectiveItemJnlLine);
+        EffectiveRatio := ItemLedgerEntry."DUoM Ratio";
+        if EffectiveRatio = 0 then
+            EffectiveRatio := EffectiveItemJnlLine."DUoM Ratio";
+
+        // Guard: sin ratio DUoM en el IJL ni ratio de lote, no hay base segura para
+        // repartir el total de la línea entre ILEs por lote. Limpia cualquier total
+        // copiado por OnAfterInitItemLedgEntry (T10).
+        if EffectiveRatio = 0 then begin
+            ItemLedgerEntry."DUoM Ratio" := 0;
+            ItemLedgerEntry."DUoM Second Qty" := 0;
             exit;
-        // Norma ILE←IJL: asignación directa del campo del IJL.
-        // El signo sigue a la cantidad EFECTIVA del ILE (ItemLedgerEntry.Quantity).
-        // ItemJnlLine.Quantity es SIEMPRE positivo en BC 27 (sin signo; la dirección
-        // la da el Entry Type), por lo que "IJL.Quantity < 0" nunca se cumple.
-        //
-        // IMPORTANTE — ILEs de corrección (Correction = true, flujos undo):
-        // Cuando BC llama CopyTrackingFromItemJnlLine para ILEs de corrección,
-        // ItemLedgerEntry.Quantity todavía tiene el mismo signo que el ILE original
-        // (BC no ha aplicado la inversión aún). Se necesita invertir el signo una vez
-        // más cuando Correction = true. Ver T-UNDO-02..05.
-        ItemLedgerEntry."DUoM Ratio" := ItemJnlLine."DUoM Ratio";
-        ItemLedgerEntry."DUoM Second Qty" := Abs(ItemJnlLine."DUoM Second Qty");
+        end;
+
+        ItemLedgerEntry."DUoM Ratio" := EffectiveRatio;
+        ItemLedgerEntry."DUoM Second Qty" := Abs(ItemLedgerEntry.Quantity) * EffectiveRatio;
         if ItemLedgerEntry.Quantity < 0 then
             ItemLedgerEntry."DUoM Second Qty" := -ItemLedgerEntry."DUoM Second Qty";
         if ItemLedgerEntry.Correction then


### PR DESCRIPTION
### Motivation
- Clarify and enforce the rule that ILE should derive DUoM Second Qty from the IJL but normalized to the ILE direction and correction flags. 
- Ensure per‑lot DUoM ratios are applied when Item Tracking is active so lot splits do not lose or duplicate DUoM totals. 
- Make Value Entry inherit the finalized DUoM Second Qty from the signed Item Ledger Entry rather than from the Item Journal Line.

### Description
- Changed `OnAfterInitItemLedgEntry` to set `Item Ledger Entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6decd764832aab12c756909c4027)