### PR TITLE
DUoM: normalize Second Qty propagation and add tracking-aware ratio handling

### DIFF
--- a/app/src/codeunit/DUoMInventorySubscribers.Codeunit.al
+++ b/app/src/codeunit/DUoMInventorySubscribers.Codeunit.al
@@ -28,32 +28,32 @@
 /// Propagation strategy for ILE:
 ///   Two parallel mechanisms cover both paths.
 ///
-///   NORMA: ILE."DUoM Second Qty" SIEMPRE viene del IJL — asignación pura, sin cálculos.
-///   La responsabilidad de que el IJL llegue con los valores correctos (signo incluido)
-///   corresponde a los subscribers upstream de cada flujo.
+///   NORMA: ILE."DUoM Second Qty" toma el módulo desde el IJL y se firma según
+///   la dirección real del ILE. La responsabilidad de que el IJL llegue con el
+///   módulo correcto corresponde a los subscribers upstream de cada flujo.
 ///
 ///   SIN Item Tracking (artículos sin lotes / sin trazabilidad activa):
 ///     OnPostItemJnlLineOnAfterCopyDocumentFields → Purchase/Sales Line → IJL  (ya existe)
 ///     OnAfterCopyItemJnlLineFromPurchRcpt / OnAfterCopyItemJnlLineFromSalesShpt → flujo undo
-///     OnAfterInitItemLedgEntry → ILE ← IJL  (asignación pura)
+///     OnAfterInitItemLedgEntry → ILE ← IJL  (módulo IJL + signo ILE)
 ///     Este subscriber siempre se dispara, con o sin tracking activo.
 ///
 ///   CON Item Tracking (por lote, BC llama CopyTrackingFromItemJnlLine solo cuando hay Lot/Serial):
 ///     ReservEntry → TrackingSpec (OnAfterCopyTrackingFromReservEntry, codeunit 50110)
 ///     OnAfterCopyTrackingFromSpec → TrackingSpec → IJL  (refinamiento por lote)
-///     OnAfterInitItemLedgEntry → ILE ← IJL  (asignación pura)
+///     OnAfterInitItemLedgEntry → ILE ← IJL  (módulo IJL + signo ILE)
 ///     OnAfterCopyTrackingFromItemJnlLine → IJL → ILE  (codeunit 50110, ILE lee del IJL)
 ///     Orden garantizado BC 27: OnAfterInitItemLedgEntry se ejecuta ANTES de
 ///     ILECopyTrackingFromItemJnlLine.
 ///
-///   IMPORTANTE: OnAfterInitItemLedgEntry es una asignación pura. Copia DUoM Ratio y
-///   DUoM Second Qty directamente del IJL al ILE sin cálculos ni lógica condicional.
-///   La responsabilidad de que el IJL llegue con valores correctos corresponde a los
-///   subscribers upstream (flujo undo, tracking copy, etc.).
+///   IMPORTANTE: OnAfterInitItemLedgEntry copia DUoM Ratio y toma DUoM Second Qty
+///   desde el IJL, normalizando únicamente el signo contra ILE.Quantity / Signed().
+///   La responsabilidad de que el IJL llegue con el módulo correcto corresponde a
+///   los subscribers upstream (flujo undo, tracking copy, etc.).
 ///
 /// Estrategia de propagación para Value Entry:
 ///   OnAfterInitValueEntry en Codeunit "Item Jnl.-Post Line" (BC 27 / runtime 15)
-///   copia DUoM Second Qty desde la Item Journal Line al nuevo Value Entry
+///   copia DUoM Second Qty desde el Item Ledger Entry ya firmado al nuevo Value Entry
 ///   antes de Insert() — no se necesita ninguna llamada a Modify().
 ///   Firma verificada: (var ValueEntry; var ItemJournalLine; var ValueEntryNo; var ItemLedgEntry).
 /// </summary>
@@ -345,16 +345,15 @@ codeunit 50104 "DUoM Inventory Subscribers"
     local procedure OnAfterInitItemLedgEntry(var NewItemLedgEntry: Record "Item Ledger Entry"; var ItemJournalLine: Record "Item Journal Line"; var ItemLedgEntryNo: Integer)
     begin
         NewItemLedgEntry."DUoM Ratio" := ItemJournalLine."DUoM Ratio";
-        NewItemLedgEntry."DUoM Second Qty" := ItemJournalLine."DUoM Second Qty";
+        NewItemLedgEntry."DUoM Second Qty" := GetSignedSecondQtyForILE(
+            NewItemLedgEntry, ItemJournalLine, GetSecondQtyForILE(NewItemLedgEntry, ItemJournalLine));
     end;
 
     /// <summary>
-    /// Asignación pura de DUoM Second Qty desde el Item Journal Line al nuevo Value Entry
-    /// antes de Insert() — sin cálculos ni lógica condicional, sin llamada a Modify().
+    /// Copia DUoM Second Qty desde el Item Ledger Entry ya firmado al nuevo Value Entry
+    /// antes de Insert() — sin llamada a Modify().
     ///
-    /// Responsabilidad única: copiar DUoM Second Qty del IJL al Value Entry.
-    /// La responsabilidad de que el IJL llegue con el valor correcto (signo incluido)
-    /// corresponde a los subscribers upstream.
+    /// Responsabilidad única: alinear el Value Entry con el ILE definitivo.
     ///
     /// Publisher: Codeunit "Item Jnl.-Post Line", evento OnAfterInitValueEntry.
     /// Firma verificada en BC 27 / runtime 15 (ItemJnlPostLine.Codeunit.al):
@@ -363,6 +362,39 @@ codeunit 50104 "DUoM Inventory Subscribers"
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Item Jnl.-Post Line", 'OnAfterInitValueEntry', '', false, false)]
     local procedure OnAfterInitValueEntry(var ValueEntry: Record "Value Entry"; var ItemJournalLine: Record "Item Journal Line"; var ValueEntryNo: Integer; var ItemLedgEntry: Record "Item Ledger Entry")
     begin
-        ValueEntry."DUoM Second Qty" := ItemJournalLine."DUoM Second Qty";
+        ValueEntry."DUoM Second Qty" := ItemLedgEntry."DUoM Second Qty";
+    end;
+
+    local procedure GetSecondQtyForILE(ItemLedgerEntry: Record "Item Ledger Entry"; ItemJournalLine: Record "Item Journal Line"): Decimal
+    begin
+        if HasTrackingContext(ItemLedgerEntry, ItemJournalLine) then begin
+            if ItemJournalLine."DUoM Ratio" = 0 then
+                exit(0);
+            if ItemLedgerEntry.Quantity <> 0 then
+                exit(Abs(ItemLedgerEntry.Quantity) * ItemJournalLine."DUoM Ratio");
+            if ItemJournalLine."Quantity (Base)" <> 0 then
+                exit(Abs(ItemJournalLine."Quantity (Base)") * ItemJournalLine."DUoM Ratio");
+        end;
+
+        exit(ItemJournalLine."DUoM Second Qty");
+    end;
+
+    local procedure GetSignedSecondQtyForILE(ItemLedgerEntry: Record "Item Ledger Entry"; ItemJournalLine: Record "Item Journal Line"; SecondQty: Decimal): Decimal
+    var
+        SignedSecondQty: Decimal;
+    begin
+        SignedSecondQty := Abs(SecondQty);
+        if ItemLedgerEntry.Quantity < 0 then
+            SignedSecondQty := -SignedSecondQty
+        else
+            if ItemLedgerEntry.Quantity = 0 then
+                SignedSecondQty := ItemJournalLine.Signed(SignedSecondQty);
+        exit(SignedSecondQty);
+    end;
+
+    local procedure HasTrackingContext(ItemLedgerEntry: Record "Item Ledger Entry"; ItemJournalLine: Record "Item Journal Line"): Boolean
+    begin
+        exit((ItemLedgerEntry."Lot No." <> '') or (ItemLedgerEntry."Serial No." <> '') or
+             (ItemJournalLine."Lot No." <> '') or (ItemJournalLine."Serial No." <> ''));
     end;
 }

--- a/app/src/codeunit/DUoMInventorySubscribers.Codeunit.al
+++ b/app/src/codeunit/DUoMInventorySubscribers.Codeunit.al
@@ -28,32 +28,32 @@
 /// Propagation strategy for ILE:
 ///   Two parallel mechanisms cover both paths.
 ///
-///   NORMA: ILE."DUoM Second Qty" toma el módulo desde el IJL y se firma según
-///   la dirección real del ILE. La responsabilidad de que el IJL llegue con el
-///   módulo correcto corresponde a los subscribers upstream de cada flujo.
+///   NORMA: ILE."DUoM Second Qty" SIEMPRE viene del IJL — asignación pura, sin cálculos.
+///   La responsabilidad de que el IJL llegue con los valores correctos (signo incluido)
+///   corresponde a los subscribers upstream de cada flujo.
 ///
 ///   SIN Item Tracking (artículos sin lotes / sin trazabilidad activa):
 ///     OnPostItemJnlLineOnAfterCopyDocumentFields → Purchase/Sales Line → IJL  (ya existe)
 ///     OnAfterCopyItemJnlLineFromPurchRcpt / OnAfterCopyItemJnlLineFromSalesShpt → flujo undo
-///     OnAfterInitItemLedgEntry → ILE ← IJL  (módulo IJL + signo ILE)
+///     OnAfterInitItemLedgEntry → ILE ← IJL  (asignación pura)
 ///     Este subscriber siempre se dispara, con o sin tracking activo.
 ///
 ///   CON Item Tracking (por lote, BC llama CopyTrackingFromItemJnlLine solo cuando hay Lot/Serial):
 ///     ReservEntry → TrackingSpec (OnAfterCopyTrackingFromReservEntry, codeunit 50110)
 ///     OnAfterCopyTrackingFromSpec → TrackingSpec → IJL  (refinamiento por lote)
-///     OnAfterInitItemLedgEntry → ILE ← IJL  (módulo IJL + signo ILE)
+///     OnAfterInitItemLedgEntry → ILE ← IJL  (asignación pura)
 ///     OnAfterCopyTrackingFromItemJnlLine → IJL → ILE  (codeunit 50110, ILE lee del IJL)
 ///     Orden garantizado BC 27: OnAfterInitItemLedgEntry se ejecuta ANTES de
 ///     ILECopyTrackingFromItemJnlLine.
 ///
-///   IMPORTANTE: OnAfterInitItemLedgEntry copia DUoM Ratio y toma DUoM Second Qty
-///   desde el IJL, normalizando únicamente el signo contra ILE.Quantity / Signed().
-///   La responsabilidad de que el IJL llegue con el módulo correcto corresponde a
-///   los subscribers upstream (flujo undo, tracking copy, etc.).
+///   IMPORTANTE: OnAfterInitItemLedgEntry es una asignación pura. Copia DUoM Ratio y
+///   DUoM Second Qty directamente del IJL al ILE sin cálculos ni lógica condicional.
+///   La responsabilidad de que el IJL llegue con valores correctos corresponde a los
+///   subscribers upstream (flujo undo, tracking copy, etc.).
 ///
 /// Estrategia de propagación para Value Entry:
 ///   OnAfterInitValueEntry en Codeunit "Item Jnl.-Post Line" (BC 27 / runtime 15)
-///   copia DUoM Second Qty desde el Item Ledger Entry ya firmado al nuevo Value Entry
+///   copia DUoM Second Qty desde la Item Journal Line al nuevo Value Entry
 ///   antes de Insert() — no se necesita ninguna llamada a Modify().
 ///   Firma verificada: (var ValueEntry; var ItemJournalLine; var ValueEntryNo; var ItemLedgEntry).
 /// </summary>
@@ -345,15 +345,21 @@ codeunit 50104 "DUoM Inventory Subscribers"
     local procedure OnAfterInitItemLedgEntry(var NewItemLedgEntry: Record "Item Ledger Entry"; var ItemJournalLine: Record "Item Journal Line"; var ItemLedgEntryNo: Integer)
     begin
         NewItemLedgEntry."DUoM Ratio" := ItemJournalLine."DUoM Ratio";
-        NewItemLedgEntry."DUoM Second Qty" := GetSignedSecondQtyForILE(
-            NewItemLedgEntry, ItemJournalLine, GetSecondQtyForILE(NewItemLedgEntry, ItemJournalLine));
+        NewItemLedgEntry."DUoM Second Qty" := Abs(ItemJournalLine."DUoM Second Qty");
+        if NewItemLedgEntry.Quantity < 0 then
+            NewItemLedgEntry."DUoM Second Qty" := -NewItemLedgEntry."DUoM Second Qty"
+        else
+            if NewItemLedgEntry.Quantity = 0 then
+                NewItemLedgEntry."DUoM Second Qty" := ItemJournalLine.Signed(NewItemLedgEntry."DUoM Second Qty");
     end;
 
     /// <summary>
-    /// Copia DUoM Second Qty desde el Item Ledger Entry ya firmado al nuevo Value Entry
-    /// antes de Insert() — sin llamada a Modify().
+    /// Asignación pura de DUoM Second Qty desde el Item Journal Line al nuevo Value Entry
+    /// antes de Insert() — sin cálculos ni lógica condicional, sin llamada a Modify().
     ///
-    /// Responsabilidad única: alinear el Value Entry con el ILE definitivo.
+    /// Responsabilidad única: copiar DUoM Second Qty del IJL al Value Entry.
+    /// La responsabilidad de que el IJL llegue con el valor correcto (signo incluido)
+    /// corresponde a los subscribers upstream.
     ///
     /// Publisher: Codeunit "Item Jnl.-Post Line", evento OnAfterInitValueEntry.
     /// Firma verificada en BC 27 / runtime 15 (ItemJnlPostLine.Codeunit.al):
@@ -363,38 +369,5 @@ codeunit 50104 "DUoM Inventory Subscribers"
     local procedure OnAfterInitValueEntry(var ValueEntry: Record "Value Entry"; var ItemJournalLine: Record "Item Journal Line"; var ValueEntryNo: Integer; var ItemLedgEntry: Record "Item Ledger Entry")
     begin
         ValueEntry."DUoM Second Qty" := ItemLedgEntry."DUoM Second Qty";
-    end;
-
-    local procedure GetSecondQtyForILE(ItemLedgerEntry: Record "Item Ledger Entry"; ItemJournalLine: Record "Item Journal Line"): Decimal
-    begin
-        if HasTrackingContext(ItemLedgerEntry, ItemJournalLine) then begin
-            if ItemJournalLine."DUoM Ratio" = 0 then
-                exit(0);
-            if ItemLedgerEntry.Quantity <> 0 then
-                exit(Abs(ItemLedgerEntry.Quantity) * ItemJournalLine."DUoM Ratio");
-            if ItemJournalLine."Quantity (Base)" <> 0 then
-                exit(Abs(ItemJournalLine."Quantity (Base)") * ItemJournalLine."DUoM Ratio");
-        end;
-
-        exit(ItemJournalLine."DUoM Second Qty");
-    end;
-
-    local procedure GetSignedSecondQtyForILE(ItemLedgerEntry: Record "Item Ledger Entry"; ItemJournalLine: Record "Item Journal Line"; SecondQty: Decimal): Decimal
-    var
-        SignedSecondQty: Decimal;
-    begin
-        SignedSecondQty := Abs(SecondQty);
-        if ItemLedgerEntry.Quantity < 0 then
-            SignedSecondQty := -SignedSecondQty
-        else
-            if ItemLedgerEntry.Quantity = 0 then
-                SignedSecondQty := ItemJournalLine.Signed(SignedSecondQty);
-        exit(SignedSecondQty);
-    end;
-
-    local procedure HasTrackingContext(ItemLedgerEntry: Record "Item Ledger Entry"; ItemJournalLine: Record "Item Journal Line"): Boolean
-    begin
-        exit((ItemLedgerEntry."Lot No." <> '') or (ItemLedgerEntry."Serial No." <> '') or
-             (ItemJournalLine."Lot No." <> '') or (ItemJournalLine."Serial No." <> ''));
     end;
 }

--- a/app/src/codeunit/DUoMTrackingCopySubscribers.Codeunit.al
+++ b/app/src/codeunit/DUoMTrackingCopySubscribers.Codeunit.al
@@ -136,8 +136,9 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
     // Patrón: Codeunit 6516 "Package Management" línea 774. Firma BC 27 confirmada.
     // Motivo: BC llama esto al dividir el IJL por lote. TrackingSpecification es el del
     // lote específico. DUoM Ratio del lote llega al IJL sin ningún FindFirst().
-    // Guard/fallback: si TrackingSpec no trae ratio, se intenta resolver DUoM Lot Ratio
-    // (50102) por Item/Lot antes de mantener el ratio de la línea.
+    // Guard: sin ratio en TrackingSpec, se sale sin sobrescribir el ratio que ya propagó
+    // OnPurchPostCopyDocFieldsToItemJnlLine desde Purchase Line (flujo sin Item Tracking
+    // o lote sin ratio DUoM registrado).
     [EventSubscriber(ObjectType::Table, Database::"Item Journal Line",
         'OnAfterCopyTrackingFromSpec', '', false, false)]
     local procedure IJLCopyTrackingFromSpec(
@@ -147,40 +148,24 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
         EffectiveRatio: Decimal;
     begin
         ItemJournalLine."Lot No." := TrackingSpecification."Lot No.";
+        EffectiveRatio := TrackingSpecification."DUoM Ratio";
+        if EffectiveRatio = 0 then
+            EffectiveRatio := GetLotRatio(TrackingSpecification, ItemJournalLine);
+        if EffectiveRatio = 0 then
+            EffectiveRatio := ItemJournalLine."DUoM Ratio";
 
-        if TrackingSpecification."DUoM Ratio" <> 0 then begin
-            SetItemJnlLineDUoMFromTrackingSpec(ItemJournalLine, TrackingSpecification, TrackingSpecification."DUoM Ratio");
+        if EffectiveRatio = 0 then begin
+            ItemJournalLine."DUoM Second Qty" := 0;
             exit;
         end;
 
-        if TryGetLotRatioFromTrackingSpec(TrackingSpecification, ItemJournalLine, EffectiveRatio) then begin
-            SetItemJnlLineDUoMFromTrackingSpec(ItemJournalLine, TrackingSpecification, EffectiveRatio);
-            exit;
-        end;
-
-        if ItemJournalLine."DUoM Ratio" <> 0 then begin
-            SetItemJnlLineDUoMFromTrackingSpec(ItemJournalLine, TrackingSpecification, ItemJournalLine."DUoM Ratio");
-            exit;
-        end;
-
-        ItemJournalLine."DUoM Second Qty" := 0;
-    end;
-
-    local procedure SetItemJnlLineDUoMFromTrackingSpec(
-        var ItemJournalLine: Record "Item Journal Line";
-        TrackingSpecification: Record "Tracking Specification";
-        DUoMRatio: Decimal)
-    begin
-        ItemJournalLine."DUoM Ratio" := DUoMRatio;
+        ItemJournalLine."DUoM Ratio" := EffectiveRatio;
         ItemJournalLine."DUoM Second Qty" := TrackingSpecification."DUoM Second Qty";
         if ItemJournalLine."DUoM Second Qty" = 0 then
-            ItemJournalLine."DUoM Second Qty" := Abs(TrackingSpecification."Quantity (Base)") * DUoMRatio;
+            ItemJournalLine."DUoM Second Qty" := Abs(TrackingSpecification."Quantity (Base)") * EffectiveRatio;
     end;
 
-    local procedure TryGetLotRatioFromTrackingSpec(
-        TrackingSpecification: Record "Tracking Specification";
-        ItemJournalLine: Record "Item Journal Line";
-        var DUoMRatio: Decimal): Boolean
+    local procedure GetLotRatio(TrackingSpecification: Record "Tracking Specification"; ItemJournalLine: Record "Item Journal Line"): Decimal
     var
         DUoMLotRatio: Record "DUoM Lot Ratio";
         DUoMSetupResolver: Codeunit "DUoM Setup Resolver";
@@ -193,36 +178,33 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
         ItemNo := TrackingSpecification."Item No.";
         if ItemNo = '' then
             ItemNo := ItemJournalLine."Item No.";
-        if ItemNo = '' then
-            exit(false);
-        if TrackingSpecification."Lot No." = '' then
-            exit(false);
+        if (ItemNo = '') or (TrackingSpecification."Lot No." = '') then
+            exit(0);
 
         VariantCode := TrackingSpecification."Variant Code";
         if VariantCode = '' then
             VariantCode := ItemJournalLine."Variant Code";
-
         if not DUoMSetupResolver.GetEffectiveSetup(ItemNo, VariantCode, SecondUoMCode, ConversionMode, FixedRatio) then
-            exit(false);
+            exit(0);
         if ConversionMode = ConversionMode::Fixed then
-            exit(false);
+            exit(0);
         if not DUoMLotRatio.Get(ItemNo, TrackingSpecification."Lot No.") then
-            exit(false);
+            exit(0);
 
-        DUoMRatio := DUoMLotRatio."Actual Ratio";
-        exit(DUoMRatio <> 0);
+        exit(DUoMLotRatio."Actual Ratio");
     end;
 
     // ── Item Journal Line → Item Ledger Entry ─────────────────────────────────
     // Publisher: Table "Item Ledger Entry" (32), evento OnAfterCopyTrackingFromItemJnlLine.
     // Patrón: Codeunit 6516 "Package Management" línea 551. Firma BC 27 confirmada.
-    // Motivo: BC llama esto antes de Insert() del ILE. Consolida los campos DUoM por
-    // lote en el ILE siguiendo la prioridad 50102 > Tracking/IJL.
+    // Motivo: BC llama esto antes de Insert() del ILE. Consolida los campos DUoM del IJL
+    // en el ILE siguiendo la norma ILE←IJL.
     //
     // Orden de ejecución (BC 27): este evento se dispara DESPUÉS de OnAfterInitItemLedgEntry.
-    // OnAfterInitItemLedgEntry (50104, parámetro var ItemJournalLine) puede haber copiado
-    // el total del IJL. Este subscriber recalcula DUoM Second Qty con la cantidad real del
-    // ILE split por lote para evitar duplicar totales en escenarios 1:N.
+    // OnAfterInitItemLedgEntry (50104, parámetro var ItemJournalLine) ya garantiza que el
+    // IJL tiene los valores definitivos: DUoM Ratio del lote (DUoM Lot Ratio si aplica) y
+    // DUoM Second Qty (módulo). El signo se aplica aquí usando ItemLedgerEntry.Quantity
+    // (ya inicializado con signo correcto por BC antes de este evento).
     //
     // NORMA ILE←IJL: el signo de ILE."DUoM Second Qty" sigue al de ILE.Quantity.
     // IJL.Quantity es SIEMPRE positivo en BC 27 (sin signo; la dirección la da Entry Type),
@@ -233,24 +215,23 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
     local procedure ILECopyTrackingFromItemJnlLine(
         var ItemLedgerEntry: Record "Item Ledger Entry";
         ItemJnlLine: Record "Item Journal Line")
-    var
-        EffectiveRatio: Decimal;
     begin
-        EffectiveRatio := ItemJnlLine."DUoM Ratio";
-
-        // Guard: sin ratio DUoM en el IJL, no hay base segura para repartir el total
-        // de la línea entre ILEs por lote. Limpia cualquier total copiado por
-        // OnAfterInitItemLedgEntry (T10).
-        if EffectiveRatio = 0 then begin
-            ItemLedgerEntry."DUoM Ratio" := 0;
-            ItemLedgerEntry."DUoM Second Qty" := 0;
+        // Guard: sin ratio DUoM en el IJL, nada que propagar al ILE.
+        // Cubre AlwaysVariable + Lot No. sin ratio (T10): Ratio = 0 aunque SecondQty ≠ 0.
+        if ItemJnlLine."DUoM Ratio" = 0 then
             exit;
-        end;
-
-        ItemLedgerEntry."DUoM Ratio" := EffectiveRatio;
+        // Norma ILE←IJL: asignación directa del campo del IJL.
+        // El signo sigue a la cantidad EFECTIVA del ILE (ItemLedgerEntry.Quantity).
+        // ItemJnlLine.Quantity es SIEMPRE positivo en BC 27 (sin signo; la dirección
+        // la da el Entry Type), por lo que "IJL.Quantity < 0" nunca se cumple.
+        //
+        // IMPORTANTE — ILEs de corrección (flujos undo):
+        // En BC 27, ItemLedgerEntry.Quantity ya refleja la dirección efectiva
+        // en este punto, por lo que no se invierte de nuevo por Correction.
+        ItemLedgerEntry."DUoM Ratio" := ItemJnlLine."DUoM Ratio";
         ItemLedgerEntry."DUoM Second Qty" := Abs(ItemJnlLine."DUoM Second Qty");
         if ItemLedgerEntry."DUoM Second Qty" = 0 then
-            ItemLedgerEntry."DUoM Second Qty" := Abs(ItemLedgerEntry.Quantity) * EffectiveRatio;
+            ItemLedgerEntry."DUoM Second Qty" := Abs(ItemLedgerEntry.Quantity) * ItemJnlLine."DUoM Ratio";
         if ItemLedgerEntry.Quantity < 0 then
             ItemLedgerEntry."DUoM Second Qty" := -ItemLedgerEntry."DUoM Second Qty";
     end;

--- a/app/src/codeunit/DUoMTrackingCopySubscribers.Codeunit.al
+++ b/app/src/codeunit/DUoMTrackingCopySubscribers.Codeunit.al
@@ -136,32 +136,93 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
     // Patrón: Codeunit 6516 "Package Management" línea 774. Firma BC 27 confirmada.
     // Motivo: BC llama esto al dividir el IJL por lote. TrackingSpecification es el del
     // lote específico. DUoM Ratio del lote llega al IJL sin ningún FindFirst().
-    // Guard: sin ratio en TrackingSpec, se sale sin sobrescribir el ratio que ya propagó
-    // OnPurchPostCopyDocFieldsToItemJnlLine desde Purchase Line (flujo sin Item Tracking
-    // o lote sin ratio DUoM registrado).
+    // Guard/fallback: si TrackingSpec no trae ratio, se intenta resolver DUoM Lot Ratio
+    // (50102) por Item/Lot antes de mantener el ratio de la línea.
     [EventSubscriber(ObjectType::Table, Database::"Item Journal Line",
         'OnAfterCopyTrackingFromSpec', '', false, false)]
     local procedure IJLCopyTrackingFromSpec(
         var ItemJournalLine: Record "Item Journal Line";
         TrackingSpecification: Record "Tracking Specification")
+    var
+        EffectiveRatio: Decimal;
     begin
-        if TrackingSpecification."DUoM Ratio" = 0 then
+        ItemJournalLine."Lot No." := TrackingSpecification."Lot No.";
+
+        if TrackingSpecification."DUoM Ratio" <> 0 then begin
+            SetItemJnlLineDUoMFromTrackingSpec(ItemJournalLine, TrackingSpecification, TrackingSpecification."DUoM Ratio");
             exit;
-        ItemJournalLine."DUoM Ratio" := TrackingSpecification."DUoM Ratio";
+        end;
+
+        if TryGetLotRatioFromTrackingSpec(TrackingSpecification, ItemJournalLine, EffectiveRatio) then begin
+            SetItemJnlLineDUoMFromTrackingSpec(ItemJournalLine, TrackingSpecification, EffectiveRatio);
+            exit;
+        end;
+
+        if ItemJournalLine."DUoM Ratio" <> 0 then begin
+            SetItemJnlLineDUoMFromTrackingSpec(ItemJournalLine, TrackingSpecification, ItemJournalLine."DUoM Ratio");
+            exit;
+        end;
+
+        ItemJournalLine."DUoM Second Qty" := 0;
+    end;
+
+    local procedure SetItemJnlLineDUoMFromTrackingSpec(
+        var ItemJournalLine: Record "Item Journal Line";
+        TrackingSpecification: Record "Tracking Specification";
+        DUoMRatio: Decimal)
+    begin
+        ItemJournalLine."DUoM Ratio" := DUoMRatio;
         ItemJournalLine."DUoM Second Qty" := TrackingSpecification."DUoM Second Qty";
+        if ItemJournalLine."DUoM Second Qty" = 0 then
+            ItemJournalLine."DUoM Second Qty" := Abs(TrackingSpecification."Quantity (Base)") * DUoMRatio;
+    end;
+
+    local procedure TryGetLotRatioFromTrackingSpec(
+        TrackingSpecification: Record "Tracking Specification";
+        ItemJournalLine: Record "Item Journal Line";
+        var DUoMRatio: Decimal): Boolean
+    var
+        DUoMLotRatio: Record "DUoM Lot Ratio";
+        DUoMSetupResolver: Codeunit "DUoM Setup Resolver";
+        ItemNo: Code[20];
+        VariantCode: Code[10];
+        SecondUoMCode: Code[10];
+        ConversionMode: Enum "DUoM Conversion Mode";
+        FixedRatio: Decimal;
+    begin
+        ItemNo := TrackingSpecification."Item No.";
+        if ItemNo = '' then
+            ItemNo := ItemJournalLine."Item No.";
+        if ItemNo = '' then
+            exit(false);
+        if TrackingSpecification."Lot No." = '' then
+            exit(false);
+
+        VariantCode := TrackingSpecification."Variant Code";
+        if VariantCode = '' then
+            VariantCode := ItemJournalLine."Variant Code";
+
+        if not DUoMSetupResolver.GetEffectiveSetup(ItemNo, VariantCode, SecondUoMCode, ConversionMode, FixedRatio) then
+            exit(false);
+        if ConversionMode = ConversionMode::Fixed then
+            exit(false);
+        if not DUoMLotRatio.Get(ItemNo, TrackingSpecification."Lot No.") then
+            exit(false);
+
+        DUoMRatio := DUoMLotRatio."Actual Ratio";
+        exit(DUoMRatio <> 0);
     end;
 
     // ── Item Journal Line → Item Ledger Entry ─────────────────────────────────
     // Publisher: Table "Item Ledger Entry" (32), evento OnAfterCopyTrackingFromItemJnlLine.
     // Patrón: Codeunit 6516 "Package Management" línea 551. Firma BC 27 confirmada.
-    // Motivo: BC llama esto antes de Insert() del ILE. Consolida los campos DUoM del IJL
-    // en el ILE siguiendo la norma ILE←IJL.
+    // Motivo: BC llama esto antes de Insert() del ILE. Consolida los campos DUoM por
+    // lote en el ILE siguiendo la prioridad 50102 > Tracking/IJL.
     //
     // Orden de ejecución (BC 27): este evento se dispara DESPUÉS de OnAfterInitItemLedgEntry.
-    // OnAfterInitItemLedgEntry (50104, parámetro var ItemJournalLine) ya garantiza que el
-    // IJL tiene los valores definitivos: DUoM Ratio del lote (DUoM Lot Ratio si aplica) y
-    // DUoM Second Qty (módulo). El signo se aplica aquí usando ItemLedgerEntry.Quantity
-    // (ya inicializado con signo correcto por BC antes de este evento).
+    // OnAfterInitItemLedgEntry (50104, parámetro var ItemJournalLine) puede haber copiado
+    // el total del IJL. Este subscriber recalcula DUoM Second Qty con la cantidad real del
+    // ILE split por lote para evitar duplicar totales en escenarios 1:N.
     //
     // NORMA ILE←IJL: el signo de ILE."DUoM Second Qty" sigue al de ILE.Quantity.
     // IJL.Quantity es SIEMPRE positivo en BC 27 (sin signo; la dirección la da Entry Type),
@@ -172,26 +233,25 @@ codeunit 50110 "DUoM Tracking Copy Subscribers"
     local procedure ILECopyTrackingFromItemJnlLine(
         var ItemLedgerEntry: Record "Item Ledger Entry";
         ItemJnlLine: Record "Item Journal Line")
+    var
+        EffectiveRatio: Decimal;
     begin
-        // Guard: sin ratio DUoM en el IJL, nada que propagar al ILE.
-        // Cubre AlwaysVariable + Lot No. sin ratio (T10): Ratio = 0 aunque SecondQty ≠ 0.
-        if ItemJnlLine."DUoM Ratio" = 0 then
+        EffectiveRatio := ItemJnlLine."DUoM Ratio";
+
+        // Guard: sin ratio DUoM en el IJL, no hay base segura para repartir el total
+        // de la línea entre ILEs por lote. Limpia cualquier total copiado por
+        // OnAfterInitItemLedgEntry (T10).
+        if EffectiveRatio = 0 then begin
+            ItemLedgerEntry."DUoM Ratio" := 0;
+            ItemLedgerEntry."DUoM Second Qty" := 0;
             exit;
-        // Norma ILE←IJL: asignación directa del campo del IJL.
-        // El signo sigue a la cantidad EFECTIVA del ILE (ItemLedgerEntry.Quantity).
-        // ItemJnlLine.Quantity es SIEMPRE positivo en BC 27 (sin signo; la dirección
-        // la da el Entry Type), por lo que "IJL.Quantity < 0" nunca se cumple.
-        //
-        // IMPORTANTE — ILEs de corrección (Correction = true, flujos undo):
-        // Cuando BC llama CopyTrackingFromItemJnlLine para ILEs de corrección,
-        // ItemLedgerEntry.Quantity todavía tiene el mismo signo que el ILE original
-        // (BC no ha aplicado la inversión aún). Se necesita invertir el signo una vez
-        // más cuando Correction = true. Ver T-UNDO-02..05.
-        ItemLedgerEntry."DUoM Ratio" := ItemJnlLine."DUoM Ratio";
+        end;
+
+        ItemLedgerEntry."DUoM Ratio" := EffectiveRatio;
         ItemLedgerEntry."DUoM Second Qty" := Abs(ItemJnlLine."DUoM Second Qty");
+        if ItemLedgerEntry."DUoM Second Qty" = 0 then
+            ItemLedgerEntry."DUoM Second Qty" := Abs(ItemLedgerEntry.Quantity) * EffectiveRatio;
         if ItemLedgerEntry.Quantity < 0 then
-            ItemLedgerEntry."DUoM Second Qty" := -ItemLedgerEntry."DUoM Second Qty";
-        if ItemLedgerEntry.Correction then
             ItemLedgerEntry."DUoM Second Qty" := -ItemLedgerEntry."DUoM Second Qty";
     end;
 


### PR DESCRIPTION
### Motivation

- Ensure `DUoM Second Qty` is taken from the Item Journal Line (IJL) but normalized to the real signed quantity of the Item Ledger Entry (ILE), and prevent duplicated totals when IJL splits into multiple ILEs. 
- Cover both non-tracked and tracked flows by consolidating lot-level DUoM propagation and providing fallbacks when a Tracking Specification lacks a ratio.

### Description

- Updated `DUoM Inventory Subscribers` to compute `DUoM Second Qty` for the new ILE using `GetSecondQtyForILE` and `GetSignedSecondQtyForILE`, and switched `OnAfterInitValueEntry` to copy the value from the finalized `Item Ledg. Entry` instead of the `Item Journal Line`.
- Added helper procedures `GetSecondQtyForILE`, `GetSignedSecondQtyForILE`, and `HasTrackingContext` to centralize logic for tracking-aware ratio calculation and sign normalization.
- Enhanced `DUoM Tracking Copy Subscribers` to set lot on IJL, prefer `TrackingSpecification.DUoM Ratio` when present, and fall back to resolving a lot-level ratio via `TryGetLotRatioFromTrackingSpec` before preserving an existing IJL ratio.
- Reworked `OnAfterCopyTrackingFromItemJnlLine` to use an `EffectiveRatio`, clear DUoM fields if no ratio is available, compute `DUoM Second Qty` from the absolute ILE quantity when needed, and apply sign from `ItemLedgerEntry.Quantity` to avoid duplicate totals across 1:N splits.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6decd764832aab12c756909c4027)